### PR TITLE
sensors: Enable bma250, apds9702 and lm3533 als

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Put the following snippet in .repo/local_manifests/c6603.xml
 
 <project path="device/sony/lagan" name="device-sony-lagan" groups="device" remote="sony" revision="master" />
 <project path="device/sony/c6603" name="device-sony-c6603" groups="device" remote="sony" revision="master" />
+<project path="vendor/sony/dash" name="DASH.git" groups="device" revision="master" remote="sony" />
 </manifest>
 ```
 
 Download the zip file with vendor binaries from:
 http://developer.sonymobile.com/downloads/tool/software-binaries-for-xperia-z/
 
-In the root of your Android code tree unzip the SW_binaries_for_Xperia_Z_v1.zip,
+In the root of your Android code tree unzip the SW_binaries_for_Xperia_Z_v2.zip,
 you should now have a directory named vendor/sony/lagan and vendor/sony/c6603 in your tree.
 
 * repo sync

--- a/full_c6603.mk
+++ b/full_c6603.mk
@@ -67,4 +67,12 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/com.nxp.mifare.xml:system/etc/permissions/com.nxp.mifare.xml \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
 
+SOMC_CFG_SENSORS_LIGHT_LM3533 := yes
+SOMC_CFG_SENSORS_LIGHT_MAXRANGE := 1000
+SOMC_CFG_SENSORS_LIGHT_LM3533_PATH := /sys/bus/i2c/devices/0-0036
+
+SOMC_CFG_SENSORS_PROXIMITY_APDS9702 := yes
+
+SOMC_CFG_SENSORS_ACCEL_BMA250_INPUT := yes
+
 $(call inherit-product-if-exists, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)


### PR DESCRIPTION
This requires the module definition of _sensors.default_ to be dropped from the zip file.
