### PR TITLE
kernel: Update kernel binary to match new binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Put the following snippet in .repo/local_manifests/c6603.xml
 Download the zip file with vendor binaries from:
 http://developer.sonymobile.com/downloads/tool/software-binaries-for-xperia-z-updated-version/
 
-In the root of your Android code tree unzip the SW_binaries_for_Xperia_Z_v2.zip,
+In the root of your Android code tree unzip the SW_binaries_for_Xperia_Z_v3.zip,
 you should now have a directory named vendor/sony/lagan and vendor/sony/c6603 in your tree.
 
 * repo sync


### PR DESCRIPTION
Kernel binary is updated to a version built from the source at [1].
A new Qualcomm baseline comes with various improvements and compatibilty
with latest prima driver code (mirrored at [2]).

[1] https://github.com/sonyxperiadev/kernel/tree/aosp/A8064AAAAANLYA161333
[2] https://github.com/sonyxperiadev/prima?source=cc

Change-Id: Ib3e72b3917fb5b9f2494cea402fbae3d6a1c3fdd
